### PR TITLE
fix pref Makefile

### DIFF
--- a/lib/pref/Makefile
+++ b/lib/pref/Makefile
@@ -6,7 +6,7 @@ font-ami.prf font-xxx.prf graf-win.prf pref-emx.prf proxy.prf \
 font-dos.prf graf-ami.prf graf-x11.prf pref-gcu.prf spell-xx.prf \
 font-ibm.prf graf-dos.prf graf-xaw.prf pref-key.prf user.prf graf-sdl.prf \
 font-mac.prf graf-gcu.prf graf-xxx.prf pref-mac.prf user-lim.prf \
-user-win.prf \ font-mon.prf graf-ibm.prf pickpref.prf pref-opt.prf \
+user-win.prf font-mon.prf graf-ibm.prf pickpref.prf pref-opt.prf \
 xtra-gcu.prf font.prf graf-mac.prf picktype.prf pref.prf xtra-new.prf \
 font-sdl.prf font-win.prf graf-new.prf pref-acn.prf pref-win.prf xtra-xxx.prf
 PACKAGE = pref


### PR DESCRIPTION
`make install` was failing with the following message due to a stray `\`
character in the middle of a line with the following message:

```
Installing  font-mon.prf...
/usr/bin/install: target 'font-mon.prf' is not a directory
Failed to install  font-mon.prf!
make[2]: *** [../../mk/buildsys.mk:437: install] Error 1
make[1]: *** [../mk/buildsys.mk:432: install] Error 2
make: *** [mk/buildsys.mk:432: install] Error 2
```

With the fix it works again.