### PR TITLE
Fix UI refresh issues and target recenter visibility

### DIFF
--- a/Project_Log.md
+++ b/Project_Log.md
@@ -1,0 +1,15 @@
+# Project Log: Frog Update
+
+## 2026-01-30
+- Established new tracking files and reset Completed items to Accepted in ask.band.
+- Archived prior development branches and reset master to upstream.
+
+## 2026-01-31
+- Completed Phase 0 build/install fixes on build/install-improvements and updated ask.band entries to Completed.
+- Added ask.band compare token rendering and documented completion format in Project_Spec.md.
+- Fixed UI refresh issues: detection/object/monster list updates, dispel buff effects refresh, and target recenter visibility rerolls.
+
+## Decisions
+- Phase 0 reserved for build/install fixes.
+- Phase 1 reserved for no-balance-change updates.
+- Phase 2 assigned to accepted updates which may touch balance or require more work.

--- a/Project_Tracker.md
+++ b/Project_Tracker.md
@@ -1,0 +1,66 @@
+# Project Tracker: Frog Update
+
+## Completed
+- Fix: Change Frog build from ncursesw5 to 6 — Sui
+- Fix: Install fails to initialize help files — gliktch
+- Fix: Install data to correct lib path — gliktch
+- Text: Document libncurses-dev dependency with fallback — gliktch
+- Text: Document path overrides (-ds/-du) for custom user/save directories — gliktch
+- Fix: Monster list not updating on teleport — gliktch
+- Fix: Refresh [] lists properly on Detection — gliktch
+- Fix: Update buff display after Dispel Magic — gliktch
+- Fix: Avoid visibility rerolls on target recenter — gliktch
+
+## Phase 0: Build + install first
+
+## Phase 1: No balance changes (prioritized)
+- Add: Ability to move viewport — gliktch
+- Add: Add Easy Object/Artifact lore options — gliktch
+- Add: Allow items to be examined in a/z/u/A menus, similar to spell browse — gliktch
+- Add: Android score in artifact lore — gliktch
+- Add: Assigning custom labels to Spells, like you already can in the Powers screen — gliktch
+- Add: Auto-recenter distance setting — gliktch
+- Add: Better feedback from search function — gliktch
+- Add: Birth option to only process fear/other checks on actions, not UI use — gliktch
+- Add: Confirmation prompt on purple disciple spell selection — gliktch
+- Add: Crits included in charsheet damage figures, or as separate figure — gliktch
+- Add: Differentiation between toggles and stackables in the charsheet — gliktch
+- Add: Disable broadcast of clvl <15 thrall deaths by default — gliktch
+- Add: Display currently 'hidden' artifact bonuses — gliktch
+- Add: Easy copying of full item lines from inventory/shop screens — gliktch
+- Add: Expand the Visual (%) menu to allow customisation of background colours — gliktch
+- Add: Highlight stun status in menus — gliktch
+- Add: Improve communication/access of pet information — gliktch
+- Add: Item Confirmation on Crafting/Artifact Creation — gliktch
+- Add: Setting for which letter automatic labels begin from — gliktch
+- Add: Settings profiles + unified config (multi-slot, diffs, birth sets) — gliktch
+- Add: Show 'Floor' tab from pressing i, not only from I — gliktch
+- Add: Show full activation names in Activation menu — gliktch
+- Fix: Artifact scroll should not destroy items — gliktch
+- Fix: Detection rod sometimes doubles up messages — gliktch
+- Fix: Magic eater fear check double-up — gliktch
+- Fix: Monster status letters wandering over screen — velo
+- Fix: Not all buildings in landmark list can be selected by letter — gliktch
+- Fix: Purple disciple being offered overlevelled spell choices after disconnect — gliktch
+- Fix: Remove/disable 'temporal files' prompt — gliktch
+- Fix: Resume pending stat point selection on next login — gliktch
+- Fix: Setting macros on function keys (F1-F12) also sets that macro on Esc key — gliktch
+- Fix: Slow monster spell sometimes yields no text output about what happened — Carolyn
+- Fix: Sometimes *Sharpness* weapons only get a single |S — gliktch
+- Fix: Spells in list not grayed out when uncastable due to low SP — gliktch
+- Fix: X11 frontend does not persist window geometry — gliktch
+- Text: Affix order inconsistent across item lines, extended descriptions and character sheet — gliktch
+- Text: Detail whether an item is standart or randart — gliktch
+
+## Phase 2: Later
+- Fix: Android bypasses progress checks, allowing farming of special stores — gliktch
+- Fix: Players shouldn't be penalised for using accessibility/UI features like automove — gliktch
+- Fix: Psion infinite money from hydras staff — JarrodB
+- Fix: Spellbook menu hides error messages until closed — gliktch
+- Fix: Stairs can't collapse with guardian alive — gliktch
+- Fix: Warlock spell damage display — gliktch
+- Fix: j move doesn't work while looking with 'l'
+- Text: Incorrect description of Slingmaster level 40 perks — gliktch
+
+## Deferred / Icebox
+- None

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -5185,6 +5185,7 @@ static void process_player(void)
                         {
                             m_ptr->mflag2 &= ~(MFLAG2_SHOW);
                             repair_monsters = TRUE;
+                            p_ptr->window |= PW_MONSTER_LIST;
                         }
                         else
                         {
@@ -5193,6 +5194,7 @@ static void process_player(void)
                             update_mon(i, FALSE);
                             check_mon_health_redraw(i);
                             lite_spot(m_ptr->fy, m_ptr->fx);
+                            p_ptr->window |= PW_MONSTER_LIST;
                         }
                     }
                 }

--- a/src/effects.c
+++ b/src/effects.c
@@ -764,6 +764,8 @@ void dispel_player(void)
         msg_print("Your hands stop glowing.");
     }
     interrupt_singing(TRUE);
+    p_ptr->redraw |= PR_EFFECTS;
+    handle_stuff();
 }
 
 

--- a/src/spells2.c
+++ b/src/spells2.c
@@ -1021,6 +1021,7 @@ bool detect_stairs(int range)
     /* Describe */
     if (detect)
     {
+        p_ptr->window |= PW_OBJECT_LIST;
         msg_print("You sense the presence of stairs!");
     }
 
@@ -1316,6 +1317,8 @@ bool detect_monsters_normal(int range)
     /* Describe */
     if (flag)
     {
+        p_ptr->window |= PW_MONSTER_LIST;
+
         /* Describe result */
         msg_print("You sense the presence of monsters!");
 
@@ -1381,6 +1384,8 @@ bool detect_monsters_invis(int range)
     /* Describe */
     if (flag)
     {
+        p_ptr->window |= PW_MONSTER_LIST;
+
         /* Describe result */
         msg_print("You sense the presence of invisible creatures!");
 
@@ -1441,6 +1446,8 @@ bool detect_monsters_evil(int range)
     /* Describe */
     if (flag)
     {
+        p_ptr->window |= PW_MONSTER_LIST;
+
         /* Describe result */
         msg_print("You sense the presence of evil creatures!");
 
@@ -1506,6 +1513,8 @@ bool detect_monsters_nonliving(int range)
     /* Describe */
     if (flag)
     {
+        p_ptr->window |= PW_MONSTER_LIST;
+
         /* Describe result */
         msg_print("You sense the presence of unnatural beings!");
 
@@ -1550,8 +1559,11 @@ bool detect_monsters_living(int range, cptr msg)
         }
     }
 
-    if (flag && msg)
-        msg_print(msg);
+    if (flag)
+    {
+        p_ptr->window |= PW_MONSTER_LIST;
+        if (msg) msg_print(msg);
+    }
 
     return flag;
 }
@@ -1606,6 +1618,7 @@ bool detect_monsters_magical(int range)
     /* Describe */
     if (flag)
     {
+        p_ptr->window |= PW_MONSTER_LIST;
         msg_print("You sense the presence of magical foes!");
     }
 
@@ -1666,6 +1679,8 @@ bool detect_monsters_mind(int range)
     /* Describe */
     if (flag)
     {
+        p_ptr->window |= PW_MONSTER_LIST;
+
         /* Describe result */
         msg_print("You sense the presence of someone's mind!");
 
@@ -1731,6 +1746,8 @@ bool detect_monsters_string(int range, cptr Match)
     /* Describe */
     if (flag)
     {
+        p_ptr->window |= PW_MONSTER_LIST;
+
         /* Describe result */
         msg_print("You sense the presence of monsters!");
 
@@ -1791,6 +1808,8 @@ bool detect_monsters_xxx(int range, u32b match_flag)
     /* Describe */
     if (flag)
     {
+        p_ptr->window |= PW_MONSTER_LIST;
+
         switch (match_flag)
         {
             case RF3_DEMON:

--- a/src/spells3.c
+++ b/src/spells3.c
@@ -158,6 +158,8 @@ bool teleport_away(int m_idx, int dis, u32b mode)
     /* Redraw the new grid */
     lite_spot(ny, nx);
 
+    p_ptr->window |= PW_MONSTER_LIST;
+
     if (r_info[m_ptr->r_idx].flags7 & (RF7_LITE_MASK | RF7_DARK_MASK))
         p_ptr->update |= (PU_MON_LITE);
 
@@ -264,6 +266,8 @@ void teleport_monster_to(int m_idx, int ty, int tx, int power, u32b mode)
 
     /* Redraw the new grid */
     lite_spot(ny, nx);
+
+    p_ptr->window |= PW_MONSTER_LIST;
 
     if (r_info[m_ptr->r_idx].flags7 & (RF7_LITE_MASK | RF7_DARK_MASK))
         p_ptr->update |= (PU_MON_LITE);

--- a/src/xtra1.c
+++ b/src/xtra1.c
@@ -2318,34 +2318,66 @@ static void prt_mon_health_bar(int m_idx, int row, int col)
         if (easy_damage || p_ptr->wizard)
         {
             char buf[20];
-            sprintf(buf, "%3d%%", pct);
-            col += 2;
-            Term_putstr(col, row, strlen(buf), attr, buf);
-            col += strlen(buf) + 1;
-            if (MON_STUNNED(m_ptr))
-            {
-                sprintf(buf, "%d%%", MON_STUNNED(m_ptr));
-                Term_putstr(col, row, strlen(buf), TERM_L_BLUE, buf);
-                col += strlen(buf) + 1;
-            }
+            char lead = ' ';
+            char status_primary = ' ';
+            byte status_attr = TERM_WHITE;
+            int  stun = MON_STUNNED(m_ptr);
+
             if (m_idx == target_who)
-                Term_queue_char(col++, row, TERM_L_RED, '*', 0, 0);
-            if (m_idx == p_ptr->riding)
-                Term_queue_char(col++, row, TERM_L_BLUE, '@', 0, 0);
+                lead = '*';
+            else if (m_idx == p_ptr->riding)
+                lead = '@';
+
+            Term_queue_char(
+                col + 1,
+                row,
+                (lead == '*') ? TERM_L_RED : (lead == '@' ? TERM_L_BLUE : base_attr),
+                lead,
+                0,
+                0
+            );
+
+            if (pct >= 100)
+                sprintf(buf, "**%%");
+            else
+                sprintf(buf, "%2d%%", pct);
+            Term_putstr(col + 2, row, 3, attr, buf);
+
             if (MON_INVULNER(m_ptr))
-                Term_queue_char(col++, row, TERM_WHITE, 'I', 0, 0);
+                Term_queue_char(col + 5, row, TERM_WHITE, 'I', 0, 0);
+
+            if (stun >= 100)
+                sprintf(buf, "**");
+            else if (stun > 0)
+                sprintf(buf, "%2d", stun);
+            else
+                sprintf(buf, "  ");
+            Term_putstr(col + 6, row, 2, TERM_L_BLUE, buf);
+
             if (MON_PARALYZED(m_ptr))
-                Term_queue_char(col++, row, TERM_BLUE, 'P', 0, 0);
-            if (MON_CSLEEP(m_ptr))
-                Term_queue_char(col++, row, TERM_BLUE, 'Z', 0, 0); /* ZZZ */
+            {
+                status_primary = 'P';
+                status_attr = TERM_BLUE;
+            }
+            else if (MON_CSLEEP(m_ptr))
+            {
+                status_primary = 'Z';
+                status_attr = TERM_BLUE;
+            }
+            else if (monster_slow(m_ptr))
+            {
+                status_primary = 'S';
+                status_attr = TERM_L_DARK;
+            }
+
+            Term_queue_char(col + 8, row, status_attr, status_primary, 0, 0);
+
             if (MON_CONFUSED(m_ptr))
-                Term_queue_char(col++, row, TERM_UMBER, 'C', 0, 0);
+                Term_queue_char(col + 9, row, TERM_UMBER, 'C', 0, 0);
             if (MON_MONFEAR(m_ptr))
-                Term_queue_char(col++, row, TERM_VIOLET, 'F', 0, 0);
+                Term_queue_char(col + 10, row, TERM_VIOLET, 'F', 0, 0);
             if (MON_FAST(m_ptr))
-                Term_queue_char(col++, row, TERM_L_BLUE, 'H', 0, 0);
-            if (monster_slow(m_ptr))
-                Term_queue_char(col++, row, TERM_L_DARK, 'S', 0, 0);
+                Term_queue_char(col + 11, row, TERM_L_BLUE, '>', 0, 0);
         }
         else
         {

--- a/src/xtra2.c
+++ b/src/xtra2.c
@@ -4762,18 +4762,6 @@ bool target_set(int mode)
                     /* Recenter the map around the player */
                     viewport_verify();
 
-                    /* Update stuff */
-                    p_ptr->update |= (PU_MONSTERS);
-
-                    /* Redraw map */
-                    p_ptr->redraw |= (PR_MAP);
-
-                    /* Window stuff */
-                    p_ptr->window |= (PW_OVERHEAD);
-
-                    /* Handle stuff */
-                    handle_stuff();
-
                     /* Recalculate interesting grids */
                     target_set_prepare(mode);
 
@@ -4994,18 +4982,6 @@ bool target_set(int mode)
                 {
                     /* Recenter the map around the player */
                     viewport_verify();
-
-                    /* Update stuff */
-                    p_ptr->update |= (PU_MONSTERS);
-
-                    /* Redraw map */
-                    p_ptr->redraw |= (PR_MAP);
-
-                    /* Window stuff */
-                    p_ptr->window |= (PW_OVERHEAD);
-
-                    /* Handle stuff */
-                    handle_stuff();
 
                     /* Recalculate interesting grids */
                     target_set_prepare(mode);


### PR DESCRIPTION
## Summary\n- refresh detection-related monster/object lists and detection expiry\n- refresh effects display after dispel magic\n- avoid visibility rerolls when recentering during targeting\n\n## Testing\n- not run (manual suggestions in notes)